### PR TITLE
Strip base path from file listing

### DIFF
--- a/aiowebdav2/client.py
+++ b/aiowebdav2/client.py
@@ -373,7 +373,7 @@ class Client:
             action="list", path=directory_urn.quote(), data=data
         )
         return WebDavXmlUtils.parse_get_list_property_response(
-            await response.read(), properties=properties
+            await response.read(), properties=properties, hostname=self._url
         )
 
     async def free(self) -> int | None:

--- a/aiowebdav2/parser.py
+++ b/aiowebdav2/parser.py
@@ -48,7 +48,7 @@ class WebDavXmlUtils:
 
     @staticmethod
     def parse_get_list_property_response(
-        content: bytes, properties: list[PropertyRequest]
+        content: bytes, properties: list[PropertyRequest], hostname: str
     ) -> dict[str, list[Property]]:
         """Parse of response content XML from WebDAV server and extract file and directory properties."""
         try:
@@ -59,6 +59,8 @@ class WebDavXmlUtils:
                 if href_el is None:
                     continue
                 path = unquote(urlsplit(href_el.text).path)
+                prefix = urlparse(hostname).path
+                path = path.removeprefix(prefix)
                 properties_dict[path] = WebDavXmlUtils.parse_get_properties_response(
                     etree.tostring(response), properties
                 )


### PR DESCRIPTION
Strip the base path from the file listing, so it is alway relative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced file listing to provide more accurate and clear file path information by incorporating additional server context.
  - Listings now automatically remove redundant URL prefixes for a cleaner and more intuitive view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->