### PR TITLE
Add content length to upload request

### DIFF
--- a/aiowebdav2/client.py
+++ b/aiowebdav2/client.py
@@ -244,6 +244,7 @@ class Client:
                 data=data,
                 proxy=self._options.proxy,
                 proxy_auth=self._options.proxy_auth,
+                chunked=True,
             )
         except ClientConnectionError as err:
             raise NoConnectionError(self._url) from err
@@ -623,6 +624,7 @@ class Client:
         remote_path: str,
         *,
         timeout: ClientTimeout | None = None,
+        content_length: int | None = None,
     ) -> None:
         """Upload file from buffer to remote path on WebDAV server.
 
@@ -631,6 +633,7 @@ class Client:
         :param buff: the buffer with content for file.
         :param str remote_path: the path to save file remotely on WebDAV server.
         :param timeout: (optional) the timeout for the request.
+        :param content_length: (optional) the length of content in buffer.
         """
         urn = Urn(remote_path)
         if urn.is_dir():
@@ -639,8 +642,16 @@ class Client:
         if not await self.check(urn.parent()):
             raise RemoteParentNotFoundError(urn.path())
 
+        headers = []
+        if content_length is not None:
+            headers.append(f"Content-Length: {content_length}")
+
         await self.execute_request(
-            action="upload", path=urn.quote(), data=buff, timeout=timeout
+            action="upload",
+            path=urn.quote(),
+            data=buff,
+            timeout=timeout,
+            headers_ext=headers,
         )
 
     async def upload(

--- a/aiowebdav2/client.py
+++ b/aiowebdav2/client.py
@@ -244,7 +244,6 @@ class Client:
                 data=data,
                 proxy=self._options.proxy,
                 proxy_auth=self._options.proxy_auth,
-                chunked=True,
             )
         except ClientConnectionError as err:
             raise NoConnectionError(self._url) from err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an option to specify the size of data during uploads, offering enhanced control over the upload process by enabling more precise data transfer handling.
  
- **Tests**
  - Added a new asynchronous test to verify the correct handling of the `Content-Length` header during uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->