### PR TITLE
Add test case for nextcloud response

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for aiowebdav2 tests."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 
 import aiohttp
 from aioresponses import aioresponses
@@ -44,3 +44,18 @@ async def client() -> AsyncGenerator[Client, None]:
         ) as c,
     ):
         yield c
+
+
+@pytest.fixture
+async def get_client() -> Callable[[str], Client]:
+    """Return a aiowebdav2 client."""
+
+    def _get_client(path: str = "/") -> Client:
+        return Client(
+            url=f"https://webdav.example.com{path}",
+            username="user",
+            password="password",
+            options=ClientOptions(disable_check=True),
+        )
+
+    return _get_client

--- a/tests/responses/nextcloud/get_list.xml
+++ b/tests/responses/nextcloud/get_list.xml
@@ -1,0 +1,30 @@
+<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+  <d:response>
+    <d:href>/remote.php/webdav/test_dir/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getlastmodified>Thu, 27 Mar 2025 20:57:35 GMT</d:getlastmodified>
+        <d:resourcetype>
+          <d:collection/>
+        </d:resourcetype>
+        <d:quota-used-bytes>28119398</d:quota-used-bytes>
+        <d:quota-available-bytes>-3</d:quota-available-bytes>
+        <d:getetag>"67e5bbbfa1185"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/webdav/test_dir/test.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getlastmodified>Thu, 27 Mar 2025 20:57:33 GMT</d:getlastmodified>
+        <d:getcontentlength>28119040</d:getcontentlength>
+        <d:resourcetype/>
+        <d:getetag>"0a24c9a7e30e635f0e273f2155bbae92"</d:getetag>
+        <d:getcontenttype>plain/text</d:getcontenttype>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced testing support with a new helper that streamlines client configuration.
  - Introduced a sample XML response simulating WebDAV metadata for directories and files.
  - Expanded test coverage by adding parameterized scenarios for the file listing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->