### PR TITLE
Remove preflight checks and relay on status codes returned by operations

### DIFF
--- a/aiowebdav2/exceptions.py
+++ b/aiowebdav2/exceptions.py
@@ -180,3 +180,16 @@ class AccessDeniedError(WebDavError):
     def __str__(self) -> str:
         """Return string representation of exception."""
         return f"Access denied to {self.path}"
+
+
+class ConflictError(WebDavError):
+    """Exception for conflict error."""
+
+    def __init__(self, path: str, message: str) -> None:
+        """Exception for conflict error."""
+        self.path = path
+        self.message = message
+
+    def __str__(self) -> str:
+        """Return string representation of exception."""
+        return f"Conflict error for {self.path} with message {self.message}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,10 @@
 
 from collections.abc import AsyncGenerator, Callable, Generator
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 
 from aiowebdav2 import Client
-from aiowebdav2.client import ClientOptions
 from tests import load_responses
 
 
@@ -35,12 +33,10 @@ def mock_responses(responses: aioresponses) -> None:
 async def client() -> AsyncGenerator[Client, None]:
     """Return a aiowebdav2 client."""
     async with (
-        aiohttp.ClientSession() as session,
         Client(
             url="https://webdav.example.com",
             username="user",
             password="password",
-            options=ClientOptions(session=session, disable_check=True),
         ) as c,
     ):
         yield c
@@ -55,7 +51,6 @@ async def get_client() -> Callable[[str], Client]:
             url=f"https://webdav.example.com{path}",
             username="user",
             password="password",
-            options=ClientOptions(disable_check=True),
         )
 
     return _get_client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -284,6 +284,12 @@ async def test_set_property(client: Client, responses: aioresponses) -> None:
 async def test_mkdir(client: Client, responses: aioresponses) -> None:
     """Test mkdir."""
     responses.add(
+        "https://webdav.example.com/test_dir/",
+        "PROPFIND",
+        status=200,
+        body=load_responses("is_dir_file.xml"),
+    )
+    responses.add(
         "https://webdav.example.com/test_dir/test_dir2/",
         "MKCOL",
         headers={"Accept": "*/*"},
@@ -500,6 +506,7 @@ async def test_client_with_external_session() -> None:
     assert not c._session.closed
 
     await external_session.close()
+    assert external_session.closed
     assert c._session.closed
 
 
@@ -588,6 +595,12 @@ async def test_upload_iter_on_dir_fails(
 
 async def test_upload_iter_parent_missing(responses: aioresponses) -> None:
     """Test upload iter on a directory."""
+    responses.add(
+        "https://webdav.example.com/test_dir/test.txt",
+        "PUT",
+        headers={"Accept": "*/*"},
+        status=409,
+    )
     responses.add(
         "https://webdav.example.com/test_dir/",
         "PROPFIND",


### PR DESCRIPTION
Remove the preflight checks, they cause some problems with some WebDAV implementaions, and fully relay on the status codes returned by the operations itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling with the introduction of a specific error message for conflict situations (HTTP 409).
  
* **Bug Fixes**
  * Enhanced reliability by refining how missing parent directories are detected during file uploads.

* **Tests**
  * Expanded test coverage to better simulate server responses and verify error handling for conflict and missing parent scenarios.

* **Chores**
  * Simplified internal options and removed obsolete configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->