### PR TITLE
Use UTF-8 encoding for basic auth

### DIFF
--- a/aiowebdav2/client.py
+++ b/aiowebdav2/client.py
@@ -238,7 +238,7 @@ class Client:
             response = await self._session.request(
                 method=method,
                 url=url,
-                auth=BasicAuth(self._username, self._password)
+                auth=BasicAuth(self._username, self._password, encoding="utf-8")
                 if (not self._options.token and not self._session.auth)
                 and (self._username and self._password)
                 else None,


### PR DESCRIPTION
Hetzner can create random passwords that need the UTF-8 encoding.
Without the encoding it will just say invalid authentication (in home assistant), causing confusion.